### PR TITLE
Add E to the list of notes that can be generated

### DIFF
--- a/app/scripts/views/main_view.coffee
+++ b/app/scripts/views/main_view.coffee
@@ -209,7 +209,7 @@ class MainView extends Backbone.Marionette.ItemView
 
   getBaseNotes : ->
 
-    return "cdfgab".split("")
+    return "cdefgab".split("")
 
 
   generateBar : (clef) ->


### PR DESCRIPTION
A simple mistake in the list of baseNotes made E disappear.
Indeed no E was ever generated in a chord.

I'm not sure why it took me more than an hour to realize it, and I'm amazed that nobody else noticed.

