### PR TITLE
Allow selecting input MIDI devices (i.e I have my preferred device as…

### DIFF
--- a/app/scripts/views/main_view.coffee
+++ b/app/scripts/views/main_view.coffee
@@ -15,6 +15,8 @@ class MainView extends Backbone.Marionette.ItemView
     <img id="image-background" src="images/piano-background.jpg">
 
     <div class="jumbotron">
+      <select id="input-devices"></select>
+
       <h1>Piano Trainer</h1>
       <a href="https://github.com/philippotto/Piano-Trainer">
         <img id="github" src="images/github.png">
@@ -59,6 +61,7 @@ class MainView extends Backbone.Marionette.ItemView
     "statistics" : "#statistics"
     "errorMessage" : "#error-message"
     "messageContainer" : "#message-container"
+    "inputDevicesSelect" : "#input-devices"
 
 
   onRender : ->
@@ -81,7 +84,9 @@ class MainView extends Backbone.Marionette.ItemView
       @onFailure.bind(@)
       @onError.bind(@),
       @onErrorResolve.bind(@)
+      @onAddInputDevices.bind(@)
     )
+    @addViewListeners()
     @initializeRenderer()
     @renderStave()
 
@@ -96,6 +101,13 @@ class MainView extends Backbone.Marionette.ItemView
   onErrorResolve : ->
 
     @ui.messageContainer.addClass("hide")
+
+  onAddInputDevices : (inputDevices) ->
+    devices = @ui.inputDevicesSelect
+
+    for inputDevice in inputDevices
+      do (inputDevice) ->
+        devices.append(new Option(inputDevice.name, inputDevice.id))
 
 
   getAllCurrentKeys : ->
@@ -143,6 +155,12 @@ class MainView extends Backbone.Marionette.ItemView
     )
 
     @renderStatistics()
+
+  addViewListeners : ->
+    midiService = @midiService
+    @ui.inputDevicesSelect.change(
+      () -> midiService.setSelectedInputDeviceById(this.value)
+    )
 
 
   renderStatistics : ->

--- a/app/styles/index.less
+++ b/app/styles/index.less
@@ -127,6 +127,9 @@ h1 {
   padding-top: 0px;
 }
 
+#input-devices {
+  float: left;
+}
 
 /* override chartist color */
 


### PR DESCRIPTION
Example fix for issue #4 

Haven't used coffeescript before, so perhaps something is out of style. 

Also didn't care for design too much. 

Could hide the selection actually if only one MIDI input device is available, but perhaps it's still nice to show it for user's debugging purposes.

Also, no tests, sry :(